### PR TITLE
Accept postgres as an valid protocol

### DIFF
--- a/src/Database/PostgreSQL/Simple/Options.hs
+++ b/src/Database/PostgreSQL/Simple/Options.hs
@@ -178,12 +178,14 @@ queryToptions Query {..} = foldM (\acc (k, v) -> fmap (mappend acc) $ keywordTop
 
 uriToptions :: URIRef Absolute -> Either String Options
 uriToptions URI {..} = case schemeBS uriScheme of
-  "postgresql" -> do
-    queryParts <- queryToptions uriQuery
-    return $ maybe mempty authorityToOptions uriAuthority <>
-      pathToptions uriPath <> queryParts
-
-  x -> Left $ "Wrong protocol. Expected \"postgresql\" but got: " ++ show x
+  "postgres" -> options
+  "postgresql" -> options
+  x -> Left $ "Wrong protocol. Expected \"postgres\" or \"postgresql\" but got: " ++ show x
+  where
+    options = do
+      queryParts <- queryToptions uriQuery
+      return $ maybe mempty authorityToOptions uriAuthority <>
+        pathToptions uriPath <> queryParts
 
 parseURIStr :: String -> Either String (URIRef Absolute)
 parseURIStr = left show . parseURI strictURIParserOptions . BSC.pack where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -43,3 +43,6 @@ main = hspec $ describe "connection string parser" $ do
         { host = return "/var/lib/postgresql"
         , dbname = return "dbname"
         })
+
+  it "accepts postgres" $ parseConnectionString "postgres://localhost"
+    `shouldBe` Right (mempty { host = return "localhost" })


### PR DESCRIPTION
Accept `postgres` as valid protocol as indicated in the [PostgreSQL Documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS). Fixes #8.